### PR TITLE
feat: 카테고리 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/mojh/daliybudget/category/controller/CategoryController.java
+++ b/src/main/java/com/mojh/daliybudget/category/controller/CategoryController.java
@@ -1,0 +1,26 @@
+package com.mojh.daliybudget.category.controller;
+
+import com.mojh.daliybudget.category.service.CategorySerivce;
+import com.mojh.daliybudget.common.web.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class CategoryController {
+
+    private final CategorySerivce categorySerivce;
+
+
+    public CategoryController(CategorySerivce categorySerivce) {
+        this.categorySerivce = categorySerivce;
+    }
+
+    @GetMapping("/api/categories")
+    public ApiResponse<List<String>> retrieveCategoryList() {
+        return ApiResponse.succeed(categorySerivce.retrieveCategoryList());
+    }
+
+}
+

--- a/src/main/java/com/mojh/daliybudget/category/domain/Category.java
+++ b/src/main/java/com/mojh/daliybudget/category/domain/Category.java
@@ -7,13 +7,15 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 @Entity
 @Getter
-@EqualsAndHashCode(of = "name", callSuper = false)
+@EqualsAndHashCode(of = "type", callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Category {
 
@@ -21,11 +23,12 @@ public class Category {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true, length = 40)
-    private String name;
+    @Column(nullable = false, unique = true)
+    @Enumerated(EnumType.STRING)
+    private CategoryType type = CategoryType.UNCATEGORIZED;
 
-    public Category(String name) {
-        this.name = name;
+    public Category(CategoryType type) {
+        this.type = type;
     }
 
 }

--- a/src/main/java/com/mojh/daliybudget/category/domain/CategoryType.java
+++ b/src/main/java/com/mojh/daliybudget/category/domain/CategoryType.java
@@ -1,0 +1,8 @@
+package com.mojh.daliybudget.category.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum CategoryType {
+    FOOD, TRANSPORTATION, SHOPPING, MEDICAL, EDUCATION, ENTERTAINMENT, FINANCE, PHONE, HOUSE, UNCATEGORIZED;
+}

--- a/src/main/java/com/mojh/daliybudget/category/repository/CategoryRepository.java
+++ b/src/main/java/com/mojh/daliybudget/category/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package com.mojh.daliybudget.category.repository;
+
+import com.mojh.daliybudget.category.domain.Category;
+import org.springframework.data.repository.CrudRepository;
+
+public interface CategoryRepository extends CrudRepository<Category, Long> {
+
+}

--- a/src/main/java/com/mojh/daliybudget/category/service/CategorySerivce.java
+++ b/src/main/java/com/mojh/daliybudget/category/service/CategorySerivce.java
@@ -1,0 +1,26 @@
+package com.mojh.daliybudget.category.service;
+
+import com.mojh.daliybudget.category.domain.CategoryType;
+import com.mojh.daliybudget.category.repository.CategoryRepository;
+import org.springframework.data.util.Streamable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CategorySerivce {
+
+    private final CategoryRepository categoryRepository;
+
+    public CategorySerivce(final CategoryRepository categoryRepository) {
+        this.categoryRepository = categoryRepository;
+    }
+
+    public List<String> retrieveCategoryList() {
+        return Streamable.of(categoryRepository.findAll())
+                         .map(c -> c.getType().name())
+                         .toList();
+    }
+
+}
+

--- a/src/test/java/com/mojh/daliybudget/category/service/CategorySerivceTest.java
+++ b/src/test/java/com/mojh/daliybudget/category/service/CategorySerivceTest.java
@@ -1,0 +1,51 @@
+package com.mojh.daliybudget.category.service;
+
+import com.mojh.daliybudget.category.domain.Category;
+import com.mojh.daliybudget.category.domain.CategoryType;
+import com.mojh.daliybudget.category.repository.CategoryRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CategorySerivceTest {
+
+    @Mock
+    CategoryRepository categoryRepository;
+
+    @InjectMocks
+    CategorySerivce categorySerivce;
+
+    @Test
+    @DisplayName("카테고리 목록 조회")
+    void retrieveCategoryList() {
+        // given
+        List<Category> categoryList = new ArrayList<>();
+        for (CategoryType type : CategoryType.values()) {
+            categoryList.add(new Category(type));
+        }
+        given(categoryRepository.findAll()).willReturn(categoryList);
+        List<String> expected = categoryList.stream()
+                                            .map(c -> c.getType().name())
+                                            .collect(Collectors.toList());
+
+        // when
+        List<String> result = categorySerivce.retrieveCategoryList();
+
+        // then
+        assertThat(result).containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,24 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
+
+    username: sa
+    password:
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: true
+    open-in-view: false
+    hibernate:
+      ddl-auto: create-drop
+
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+
+  h2:
+    console:
+      enabled: true


### PR DESCRIPTION
## 📃 설명

- resolves #7
- 

## 🔨 작업 내용

1. 카테고리 enum 정의
   - 일단 개발을 위해 FOOD, TRANSPORTATION, SHOPPING, MEDICAL, EDUCATION, ENTERTAINMENT, FINANCE, PHONE, HOUSE, UNCATEGORIZED 만 정의
   - 이후에 필요하면 더 추가 예정
3. 카테고리 목록 조회 구현
4. 카테고리 서비스 단위 테스트로 카테고리 목록 조회 테스트 작성

## 💬 기타 사항

- 카테고리가 db에 입력된 값과 서버의 enum에서 정의한 값이 같은지 검증이 필요할 것 같은데 개발을 좀 더 하고 추가해봐야 될 것 같다