### PR TITLE
feat: 예산 설정 API 구현

### DIFF
--- a/src/main/java/com/mojh/dailybudget/category/domain/CategoryType.java
+++ b/src/main/java/com/mojh/dailybudget/category/domain/CategoryType.java
@@ -1,8 +1,21 @@
 package com.mojh.dailybudget.category.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
+
+import java.util.stream.Stream;
 
 @Getter
 public enum CategoryType {
     FOOD, TRANSPORTATION, SHOPPING, MEDICAL, EDUCATION, ENTERTAINMENT, FINANCE, PHONE, HOUSE, UNCATEGORIZED;
+
+    @JsonCreator
+    public static CategoryType parse(String input) {
+        String inputUpperCase = input.toUpperCase();
+        return Stream.of(CategoryType.values())
+                     .filter(type -> type.toString().equals(inputUpperCase))
+                     .findFirst()
+                     .orElse(null);
+    }
+
 }

--- a/src/main/java/com/mojh/dailybudget/common/vaildation/EnumValidator.java
+++ b/src/main/java/com/mojh/dailybudget/common/vaildation/EnumValidator.java
@@ -5,26 +5,9 @@ import javax.validation.ConstraintValidatorContext;
 
 public class EnumValidator implements ConstraintValidator<ValidEnum, Enum<?>> {
 
-    private ValidEnum annotation;
-
     @Override
-    public void initialize(ValidEnum constraintAnnotation) {
-        this.annotation = constraintAnnotation;
-    }
-
-    @Override
-    public boolean isValid(Enum value, ConstraintValidatorContext context) {
-        Enum<?>[] enumValues = this.annotation.enumClass().getEnumConstants();
-        if(value == null || enumValues == null) {
-            return false;
-        }
-
-        for (Enum<?> enumValue : enumValues) {
-            if (enumValue.equals(value)) {
-                return true;
-            }
-        }
-        return false;
+    public boolean isValid(Enum<?> value, ConstraintValidatorContext context) {
+        return value != null;
     }
 
 }

--- a/src/main/java/com/mojh/dailybudget/common/vaildation/ValidEnum.java
+++ b/src/main/java/com/mojh/dailybudget/common/vaildation/ValidEnum.java
@@ -19,12 +19,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
 public @interface ValidEnum {
 
-    String message() default "Invalid Enum";
+    String message() default "Invalid Enum Value";
 
     Class<?>[] groups() default {};
 
     Class<? extends Payload>[] payload() default {};
-
-    Class<? extends java.lang.Enum<?>> enumClass();
 
 }

--- a/src/main/java/com/mojh/dailybudget/member/domain/Role.java
+++ b/src/main/java/com/mojh/dailybudget/member/domain/Role.java
@@ -1,5 +1,19 @@
 package com.mojh.dailybudget.member.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.stream.Stream;
+
 public enum Role {
     ROLE_USER;
+
+    @JsonCreator
+    public static Role parse(String input) {
+        String inputUpperCase = input.toUpperCase();
+        return Stream.of(Role.values())
+                     .filter(role -> role.toString().equals(inputUpperCase))
+                     .findFirst()
+                     .orElse(null);
+    }
+
 }

--- a/src/main/java/com/mojh/dailybudget/member/dto/MemberSignupRequest.java
+++ b/src/main/java/com/mojh/dailybudget/member/dto/MemberSignupRequest.java
@@ -22,7 +22,7 @@ public class MemberSignupRequest {
     @Size(min = 8, max = 20)
     private String password;
 
-    @ValidEnum(enumClass = Role.class)
+    @ValidEnum
     private Role role;
 
     @NotBlank


### PR DESCRIPTION
## 📃 설명

- resolves #2 
- 

## 🔨 작업 내용

1. enum validation 방식 수정
  - 기존 방식은 dto 필드에서 enum 타입으로 받고 custom validator로 처리
    - enum 필드에 맞지 않은 입력 값이 들어왔을 때 custom vaildator 에서 처리되기 전에 json 역직렬화 하면서 InvalidFormatException가 먼저 발생
  - 그래서 각 enum에 `@JsonCreator`을 선언한 정적 함수 만들어서 enum 필드 값에 맞지 않은 입력값이 오면 null로 바꾸고 dto에서 `enum != null` 인지만 확인하는 custom validator 적용
    - 이렇게 하면 기존의 Validation 관련 annotation 적용했을 때랑 같은 방식을 에러 메시지 출력됨
    - 그러나 입력받을 수 있는 enum 마다 해당 코드를 만들어야 됨
    - interface와 default method로 코드 중복 줄이려 했으나 해당 인터페이스를 구현하는 enum 클래스 타입에 대해서 generic T로 처리 했는데 결국 enum의 values나 valueOf 이런 것을 사용할 수 없음
    - 정적 메서드에서 당연하게 T에 대한 타입을 처리할 수 없음
    - 더 나은 방법 있으면 바꾸는 걸로...
3. 
4. 

## 💬 기타 사항

- 