### PR TITLE
feat: 지출 생성 API 구현

### DIFF
--- a/src/main/java/com/mojh/dailybudget/budget/controller/BudgetController.java
+++ b/src/main/java/com/mojh/dailybudget/budget/controller/BudgetController.java
@@ -29,7 +29,7 @@ public class BudgetController {
 
     @PutMapping("/budgets")
     public ResponseEntity<?> putBudget(@RequestBody @Valid final BudgetPutRequest request,
-                                                    @LoginMember Member member) {
+                                       @LoginMember Member member) {
         PutResultResponse putResultResponse = budgetService.putBudget(request, member);
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()

--- a/src/main/java/com/mojh/dailybudget/category/repository/CategoryRepository.java
+++ b/src/main/java/com/mojh/dailybudget/category/repository/CategoryRepository.java
@@ -1,8 +1,13 @@
 package com.mojh.dailybudget.category.repository;
 
 import com.mojh.dailybudget.category.domain.Category;
+import com.mojh.dailybudget.category.domain.CategoryType;
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.Optional;
+
 public interface CategoryRepository extends CrudRepository<Category, Long> {
+
+    Optional<Category> findByType(CategoryType type);
 
 }

--- a/src/main/java/com/mojh/dailybudget/category/service/CategorySerivce.java
+++ b/src/main/java/com/mojh/dailybudget/category/service/CategorySerivce.java
@@ -1,10 +1,15 @@
 package com.mojh.dailybudget.category.service;
 
+import com.mojh.dailybudget.category.domain.Category;
+import com.mojh.dailybudget.category.domain.CategoryType;
 import com.mojh.dailybudget.category.repository.CategoryRepository;
+import com.mojh.dailybudget.common.exception.DailyBudgetAppException;
 import org.springframework.data.util.Streamable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+
+import static com.mojh.dailybudget.common.exception.ErrorCode.CATEGORY_NOT_FOUND;
 
 @Service
 public class CategorySerivce {
@@ -19,6 +24,11 @@ public class CategorySerivce {
         return Streamable.of(categoryRepository.findAll())
                          .map(c -> c.getType().name())
                          .toList();
+    }
+
+    public Category findByCategoryType(CategoryType categoryType) {
+        return categoryRepository.findByType(categoryType)
+                                 .orElseThrow(() -> new DailyBudgetAppException(CATEGORY_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/mojh/dailybudget/common/exception/ErrorCode.java
+++ b/src/main/java/com/mojh/dailybudget/common/exception/ErrorCode.java
@@ -32,9 +32,12 @@ public enum ErrorCode {
 
 
     // budget
-    TOTAL_BUDGET_LIMIT_EXCESS(BAD_REQUEST, "BUD0001", "총 예산은 1조원을 초과하여 설정할 수 없습니다.")
+    TOTAL_BUDGET_LIMIT_EXCESS(BAD_REQUEST, "BUD0001", "총 예산은 1조원을 초과하여 설정할 수 없습니다."),
 
     // expenditure
+
+    // category
+    CATEGORY_NOT_FOUND(NOT_FOUND, "C0001", "카테고리를 찾을 수 없습니다.")
 
     ;
 

--- a/src/main/java/com/mojh/dailybudget/expenditure/controller/ExpenditureController.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/controller/ExpenditureController.java
@@ -1,0 +1,43 @@
+package com.mojh.dailybudget.expenditure.controller;
+
+import com.mojh.dailybudget.auth.domain.LoginMember;
+import com.mojh.dailybudget.budget.dto.BudgetPutRequest;
+import com.mojh.dailybudget.expenditure.dto.ExpenditureCreateRequest;
+import com.mojh.dailybudget.expenditure.service.ExpenditureService;
+import com.mojh.dailybudget.member.domain.Member;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.function.EntityResponse;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import javax.validation.Valid;
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/expenditures")
+public class ExpenditureController {
+
+    private final ExpenditureService expenditureService;
+
+    public ExpenditureController(final ExpenditureService expenditureService) {
+        this.expenditureService = expenditureService;
+    }
+
+    @PostMapping
+    public ResponseEntity createExpenditure(@RequestBody @Valid final ExpenditureCreateRequest request,
+                                            @LoginMember final Member member) {
+        Long id = expenditureService.createExpenditure(request, member);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                                                  .path("/{id}")
+                                                  .buildAndExpand(id)
+                                                  .toUri();
+
+        return ResponseEntity.created(location)
+                             .build();
+    }
+
+
+}

--- a/src/main/java/com/mojh/dailybudget/expenditure/domain/Expenditure.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/domain/Expenditure.java
@@ -1,6 +1,7 @@
 package com.mojh.dailybudget.expenditure.domain;
 
 import com.mojh.dailybudget.category.domain.Category;
+import com.mojh.dailybudget.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -25,6 +27,10 @@ public class Expenditure {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @ManyToOne
     @JoinColumn(name = "category_id", nullable = false)
@@ -43,8 +49,9 @@ public class Expenditure {
     private LocalDateTime expenditureAt;
 
     @Builder
-    public Expenditure(Category category, Long amount, String memo,
+    public Expenditure(Member member, Category category, Long amount, String memo,
                        Boolean excludeFromTotal, LocalDateTime expenditureAt) {
+        this.member = member;
         this.category = category;
         this.amount = amount;
         this.memo = memo;

--- a/src/main/java/com/mojh/dailybudget/expenditure/dto/ExpenditureCreateRequest.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/dto/ExpenditureCreateRequest.java
@@ -1,0 +1,55 @@
+package com.mojh.dailybudget.expenditure.dto;
+
+import com.mojh.dailybudget.category.domain.Category;
+import com.mojh.dailybudget.category.domain.CategoryType;
+import com.mojh.dailybudget.common.vaildation.ValidEnum;
+import com.mojh.dailybudget.expenditure.domain.Expenditure;
+import com.mojh.dailybudget.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Range;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExpenditureCreateRequest {
+
+    @ValidEnum
+    private CategoryType category;
+
+    @Range(min = 0L, max = 1000000000000L)
+    private Long amount;
+
+    @Size(max = 40)
+    private String memo = "";
+
+    private Boolean excludeFromTotal = false;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime expenditureAt;
+
+    public ExpenditureCreateRequest(CategoryType category, Long amount, String memo,
+                                    Boolean excludeFromTotal, LocalDateTime expenditureAt) {
+        this.category = category;
+        this.amount = amount;
+        this.memo = memo;
+        this.excludeFromTotal = excludeFromTotal;
+        this.expenditureAt = expenditureAt;
+    }
+
+    public Expenditure toEntity(Member member, Category category) {
+        return Expenditure.builder()
+                          .member(member)
+                          .category(category)
+                          .amount(amount)
+                          .memo(memo)
+                          .excludeFromTotal(excludeFromTotal)
+                          .expenditureAt(expenditureAt)
+                          .build();
+    }
+
+}

--- a/src/main/java/com/mojh/dailybudget/expenditure/repository/ExpenditureRepository.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/repository/ExpenditureRepository.java
@@ -1,0 +1,8 @@
+package com.mojh.dailybudget.expenditure.repository;
+
+import com.mojh.dailybudget.expenditure.domain.Expenditure;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExpenditureRepository extends JpaRepository<Expenditure, Long> {
+
+}

--- a/src/main/java/com/mojh/dailybudget/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/service/ExpenditureService.java
@@ -1,0 +1,32 @@
+package com.mojh.dailybudget.expenditure.service;
+
+import com.mojh.dailybudget.category.domain.Category;
+import com.mojh.dailybudget.category.service.CategorySerivce;
+import com.mojh.dailybudget.expenditure.domain.Expenditure;
+import com.mojh.dailybudget.expenditure.dto.ExpenditureCreateRequest;
+import com.mojh.dailybudget.expenditure.repository.ExpenditureRepository;
+import com.mojh.dailybudget.member.domain.Member;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ExpenditureService {
+
+    private final ExpenditureRepository expenditureRepository;
+    private final CategorySerivce categoryService;
+
+    public ExpenditureService(final ExpenditureRepository expenditureRepository,
+                              final CategorySerivce categoryService) {
+        this.expenditureRepository = expenditureRepository;
+        this.categoryService = categoryService;
+    }
+
+    @Transactional
+    public Long createExpenditure(ExpenditureCreateRequest request, Member member) {
+        Category category = categoryService.findByCategoryType(request.getCategory());
+        Expenditure expenditure = request.toEntity(member, category);
+
+        return expenditureRepository.save(expenditure).getId();
+    }
+
+}


### PR DESCRIPTION
## 📃 설명

- resolves #8
- 

## 🔨 작업 내용

1. 지출 생성 API 구현
2. CategoryType 으로 Category 조회를 CategoryService에 따로 구현
   - 지출 service 에서 CategoryRepository에서 직접 호출해도 되나 일단은 CategoryService에서 따로 함수 만들어봄
4. 지출 entity 필드의 member fk 추가
   - 제일 중요한 member 연관관계 추가를 안함, 유저와 지출 1:n 관계로 설정
 

## 💬 기타 사항

- 지출 생성할 때 합계 제외(exclude_from_total)필드도 같이 입력받고 해당 필드 없을 땐 기본값 false
- 이후 지출 수정 API에서도 합계 제외 수정 가능하게 하면 될듯