### PR TITLE
feat: 지출 수정 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	// lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
 	// log4j2

--- a/src/main/java/com/mojh/dailybudget/auth/domain/MemberAdapter.java
+++ b/src/main/java/com/mojh/dailybudget/auth/domain/MemberAdapter.java
@@ -1,11 +1,13 @@
 package com.mojh.dailybudget.auth.domain;
 
 import com.mojh.dailybudget.member.domain.Member;
+import lombok.Getter;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 
 import java.util.List;
 
+@Getter
 public class MemberAdapter extends User {
 
     private Member member;

--- a/src/main/java/com/mojh/dailybudget/budget/domain/Budget.java
+++ b/src/main/java/com/mojh/dailybudget/budget/domain/Budget.java
@@ -1,6 +1,6 @@
 package com.mojh.dailybudget.budget.domain;
 
-import com.mojh.dailybudget.common.entity.BaseTimeEntity;
+import com.mojh.dailybudget.common.domain.BaseTimeEntity;
 import com.mojh.dailybudget.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/mojh/dailybudget/common/domain/BaseCreatedTimeEntity.java
+++ b/src/main/java/com/mojh/dailybudget/common/domain/BaseCreatedTimeEntity.java
@@ -1,9 +1,10 @@
-package com.mojh.dailybudget.common.entity;
+package com.mojh.dailybudget.common.domain;
 
 import lombok.Getter;
-import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
@@ -11,9 +12,9 @@ import java.time.LocalDateTime;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseTimeEntity extends BaseCreatedTimeEntity {
+public abstract class BaseCreatedTimeEntity {
 
-    @LastModifiedDate
-    protected LocalDateTime updatedAt;
+    @CreatedDate
+    @Column(updatable = false)
+    protected LocalDateTime createdAt;
 }
-

--- a/src/main/java/com/mojh/dailybudget/common/domain/BaseTimeEntity.java
+++ b/src/main/java/com/mojh/dailybudget/common/domain/BaseTimeEntity.java
@@ -1,10 +1,9 @@
-package com.mojh.dailybudget.common.entity;
+package com.mojh.dailybudget.common.domain;
 
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
@@ -12,9 +11,9 @@ import java.time.LocalDateTime;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseCreatedTimeEntity {
+public abstract class BaseTimeEntity extends BaseCreatedTimeEntity {
 
-    @CreatedDate
-    @Column(updatable = false)
-    protected LocalDateTime createdAt;
+    @LastModifiedDate
+    protected LocalDateTime updatedAt;
 }
+

--- a/src/main/java/com/mojh/dailybudget/common/domain/Patchable.java
+++ b/src/main/java/com/mojh/dailybudget/common/domain/Patchable.java
@@ -1,0 +1,16 @@
+package com.mojh.dailybudget.common.domain;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Patchable {
+    /**
+     * null인 필드는 무시, 기본 값 true
+     * @return
+     */
+    boolean ignoreNull() default true;
+}

--- a/src/main/java/com/mojh/dailybudget/common/domain/PatchableFieldUtil.java
+++ b/src/main/java/com/mojh/dailybudget/common/domain/PatchableFieldUtil.java
@@ -1,0 +1,114 @@
+package com.mojh.dailybudget.common.domain;
+
+import com.mojh.dailybudget.common.exception.DailyBudgetAppException;
+import com.mojh.dailybudget.common.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.annotation.Annotation;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Entity patch 작업을 위한 중복 코드 생성을 줄이는 util class.
+ * <p>
+ * ref = https://blog.gangnamunni.com/post/Annotation-Reflection-Entity-update/
+ */
+@Slf4j
+public final class PatchableFieldUtil {
+
+    /**
+     * 요청한 값에 따라 entity의 필드를 변경한다.
+     * @param targetObj 변경 대상인 기존 리소스
+     * @param requestObj 변경 요청 데이터
+     * @return
+     * @param <T>
+     */
+    public static <T> boolean patch(T targetObj, T requestObj) {
+        if (requestObj == null) {
+            return false;
+        }
+
+        if (targetObj.getClass() != requestObj.getClass()) {
+            throw new DailyBudgetAppException(ErrorCode.COM_PATCH_FAILED);
+        }
+
+        // Lambda 안에서 updated 를 접근하기 위한 AtomicReference
+        final AtomicReference<Boolean> updated = new AtomicReference<>(false);
+
+        List<String> patchedList = new LinkedList<>();
+
+        // 대상 클래스의 모든 Super class의 모든 field에 대해 지정된 콜백 호출(조건에 해당하는 필드만)
+        ReflectionUtils.doWithFields(targetObj.getClass(),
+                field -> {
+                    // 해당 값을 true로 설정해야 private, protected 같이 제한된 데이터 접근 가능
+                    field.setAccessible(true);
+                    Object oldValue = field.get(targetObj);
+                    Object newValue = field.get(requestObj);
+                    boolean canPatch = false;
+                    final Patchable annotation = field.getAnnotation(Patchable.class);
+
+                    if (annotation.ignoreNull()) {
+                        // 기본 값, 요청 데이터가 null이면 변경 x
+                        if (PatchableFieldUtil.canUpdate(oldValue, newValue)) {
+                            canPatch = true;
+                        }
+                    } else {
+                        // 요청 데이터가 null이어도 변경 가능
+                        if (PatchableFieldUtil.canUpdateAlbeitNull(oldValue, newValue)) {
+                            canPatch = true;
+                        }
+                    }
+
+                    if (canPatch) {
+                        field.set(targetObj, newValue);
+                        updated.set(true);
+                        patchedList.add(String.format("%s : %s -> %s", field.getName(), oldValue, newValue));
+                    }
+
+                },
+                field -> {
+                    // 콜백을 적용할 필드를 결정하는 필터 로직
+                    final Annotation annotation = field.getAnnotation(Patchable.class);
+                    return annotation != null;
+                });
+
+        if (updated.get()) {
+            log.info(String.join("\n", patchedList));
+        }
+
+        return updated.get();
+    }
+
+    /**
+     * 변경 요청 데이터가 null이 아니고 기존 데이터와 다르면 변경 가능
+     * @param to 기존 데이터
+     * @param from 변경 요청 데이터
+     * @return 변경 가능 여부
+     * @param <T>
+     */
+    public static <T> boolean canUpdate(T to, T from) {
+        if (from != null && !from.equals(to)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 변경 요청 데이터가 null이어도 기존 데이터가 null이 아니면 변경 가능
+     * <p>
+     * 변경 요청 데이터가 null이 아닌 값일 때에는 기존 데이터와 다를 때 변경 가능
+     * @param to 기존 데이터
+     * @param from 변경 요청 데이터
+     * @return 변경 가능 여부
+     * @param <T>
+     */
+    public static <T> boolean canUpdateAlbeitNull(T to, T from) {
+        if (from == null) {
+            return to != null;
+        }
+        return !from.equals(to);
+    }
+
+}

--- a/src/main/java/com/mojh/dailybudget/common/exception/ErrorCode.java
+++ b/src/main/java/com/mojh/dailybudget/common/exception/ErrorCode.java
@@ -2,7 +2,6 @@ package com.mojh.dailybudget.common.exception;
 
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.client.HttpClientErrorException;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
@@ -36,9 +35,11 @@ public enum ErrorCode {
     TOTAL_BUDGET_LIMIT_EXCESS(BAD_REQUEST, "BUD0001", "총 예산은 1조원을 초과하여 설정할 수 없습니다."),
 
     // expenditure
+    EXPENDITURE_NOT_FOUND(NOT_FOUND, "EXP0001", "지출 정보를 찾을 수 없습니다."),
+    EXPENDITURE_MEMBER_MISMATCH(BAD_REQUEST, "EXP0002", "해당 지출 정보를 작성한 유저와 다릅니다."),
 
     // category
-    CATEGORY_NOT_FOUND(NOT_FOUND, "C0001", "카테고리를 찾을 수 없습니다.")
+    CATEGORY_NOT_FOUND(NOT_FOUND, "CATE0001", "카테고리를 찾을 수 없습니다.")
 
     ;
 

--- a/src/main/java/com/mojh/dailybudget/common/exception/ErrorCode.java
+++ b/src/main/java/com/mojh/dailybudget/common/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     COM_INTERNAL_SERVER_ERROR(INTERNAL_SERVER_ERROR, "COM0000", "시스템 오류입니다."),
     COM_BAD_REQUEST(BAD_REQUEST, "COM0001", "잘못된 요청입니다."),
     COM_INVALID_PARAMETERS(BAD_REQUEST, "COM0002", "유효하지 않은 파라미터입니다."),
+    COM_PATCH_FAILED(BAD_REQUEST, "COM0003", "데이터 수정에 실패했습니다."),
 
     // member
     MEMBER_NOT_FOUND(NOT_FOUND, "MEM0001", "유저를 찾을 수 없습니다."),

--- a/src/main/java/com/mojh/dailybudget/expenditure/controller/ExpenditureController.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/controller/ExpenditureController.java
@@ -1,18 +1,22 @@
 package com.mojh.dailybudget.expenditure.controller;
 
 import com.mojh.dailybudget.auth.domain.LoginMember;
-import com.mojh.dailybudget.budget.dto.BudgetPutRequest;
+import com.mojh.dailybudget.common.web.ApiResponse;
 import com.mojh.dailybudget.expenditure.dto.ExpenditureCreateRequest;
+import com.mojh.dailybudget.expenditure.dto.ExpenditureUpdateRequest;
 import com.mojh.dailybudget.expenditure.service.ExpenditureService;
 import com.mojh.dailybudget.member.domain.Member;
+import org.springframework.http.HttpRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.function.EntityResponse;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.net.URI;
 
@@ -28,15 +32,23 @@ public class ExpenditureController {
 
     @PostMapping
     public ResponseEntity createExpenditure(@RequestBody @Valid final ExpenditureCreateRequest request,
-                                            @LoginMember final Member member) {
+                                            @LoginMember final Member member,
+                                            HttpServletRequest sr) {
         Long id = expenditureService.createExpenditure(request, member);
-        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+        URI location = ServletUriComponentsBuilder.fromCurrentRequestUri()
                                                   .path("/{id}")
                                                   .buildAndExpand(id)
                                                   .toUri();
 
-        return ResponseEntity.created(location)
-                             .build();
+        return ResponseEntity.created(location).build();
+    }
+
+    @PatchMapping("/{expenditureId}")
+    public ApiResponse<Boolean> updateExpenditure(@RequestBody @Valid final ExpenditureUpdateRequest request,
+                                                  @LoginMember final Member member,
+                                                  @PathVariable Long expenditureId) {
+        Boolean updated = expenditureService.updateExpenditure(request, member, expenditureId);
+        return ApiResponse.succeed(updated);
     }
 
 

--- a/src/main/java/com/mojh/dailybudget/expenditure/domain/Expenditure.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/domain/Expenditure.java
@@ -2,6 +2,8 @@ package com.mojh.dailybudget.expenditure.domain;
 
 import com.mojh.dailybudget.category.domain.Category;
 import com.mojh.dailybudget.common.domain.BaseTimeEntity;
+import com.mojh.dailybudget.common.domain.Patchable;
+import com.mojh.dailybudget.common.domain.PatchableFieldUtil;
 import com.mojh.dailybudget.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -33,19 +35,24 @@ public class Expenditure extends BaseTimeEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @ManyToOne
+    @Patchable
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
+    @Patchable
     @Column(nullable = false)
     private Long amount;
 
+    @Patchable
     @Column(nullable = false, columnDefinition = "char", length = 40)
     private String memo;
 
+    @Patchable
     @Column(nullable = false)
     private Boolean excludeFromTotal;
 
+    @Patchable
     @Column(nullable = false)
     private LocalDateTime expenditureAt;
 
@@ -58,6 +65,14 @@ public class Expenditure extends BaseTimeEntity {
         this.memo = memo;
         this.excludeFromTotal = excludeFromTotal;
         this.expenditureAt = expenditureAt;
+    }
+
+    public boolean isOwner(Member member) {
+        return this.member.equals(member);
+    }
+
+    public boolean update(Object requestObj) {
+        return PatchableFieldUtil.patch(this, requestObj);
     }
 
 }

--- a/src/main/java/com/mojh/dailybudget/expenditure/domain/Expenditure.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/domain/Expenditure.java
@@ -1,6 +1,7 @@
 package com.mojh.dailybudget.expenditure.domain;
 
 import com.mojh.dailybudget.category.domain.Category;
+import com.mojh.dailybudget.common.domain.BaseTimeEntity;
 import com.mojh.dailybudget.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -22,7 +23,7 @@ import java.time.LocalDateTime;
 @Getter
 @EqualsAndHashCode(of = "id", callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Expenditure {
+public class Expenditure extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/mojh/dailybudget/expenditure/dto/ExpenditureCreateRequest.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/dto/ExpenditureCreateRequest.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.format.annotation.DateTimeFormat;
 
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
 
@@ -29,6 +30,7 @@ public class ExpenditureCreateRequest {
 
     private Boolean excludeFromTotal = false;
 
+    @NotNull
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime expenditureAt;
 

--- a/src/main/java/com/mojh/dailybudget/expenditure/dto/ExpenditureUpdateRequest.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/dto/ExpenditureUpdateRequest.java
@@ -1,0 +1,53 @@
+package com.mojh.dailybudget.expenditure.dto;
+
+import com.mojh.dailybudget.category.domain.Category;
+import com.mojh.dailybudget.category.domain.CategoryType;
+import com.mojh.dailybudget.common.vaildation.ValidEnum;
+import com.mojh.dailybudget.expenditure.domain.Expenditure;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Range;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExpenditureUpdateRequest {
+
+    @ValidEnum
+    private CategoryType category;
+
+    @Range(min = 0L, max = 1000000000000L)
+    private Long amount;
+
+    @Size(max = 40)
+    private String memo;
+
+    private Boolean excludeFromTotal;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime expenditureAt;
+
+    public ExpenditureUpdateRequest(CategoryType category, Long amount, String memo,
+                                    Boolean excludeFromTotal, LocalDateTime expenditureAt) {
+        this.category = category;
+        this.amount = amount;
+        this.memo = memo;
+        this.excludeFromTotal = excludeFromTotal;
+        this.expenditureAt = expenditureAt;
+    }
+
+    public Expenditure toEntity(Category category) {
+        return Expenditure.builder()
+                          .category(category)
+                          .amount(amount)
+                          .memo(memo)
+                          .excludeFromTotal(excludeFromTotal)
+                          .expenditureAt(expenditureAt)
+                          .build();
+    }
+
+}

--- a/src/main/java/com/mojh/dailybudget/expenditure/dto/ExpenditureUpdateRequest.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/dto/ExpenditureUpdateRequest.java
@@ -5,6 +5,7 @@ import com.mojh.dailybudget.category.domain.CategoryType;
 import com.mojh.dailybudget.common.vaildation.ValidEnum;
 import com.mojh.dailybudget.expenditure.domain.Expenditure;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Range;
@@ -31,6 +32,7 @@ public class ExpenditureUpdateRequest {
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime expenditureAt;
 
+    @Builder
     public ExpenditureUpdateRequest(CategoryType category, Long amount, String memo,
                                     Boolean excludeFromTotal, LocalDateTime expenditureAt) {
         this.category = category;

--- a/src/main/java/com/mojh/dailybudget/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/service/ExpenditureService.java
@@ -2,12 +2,17 @@ package com.mojh.dailybudget.expenditure.service;
 
 import com.mojh.dailybudget.category.domain.Category;
 import com.mojh.dailybudget.category.service.CategorySerivce;
+import com.mojh.dailybudget.common.exception.DailyBudgetAppException;
 import com.mojh.dailybudget.expenditure.domain.Expenditure;
 import com.mojh.dailybudget.expenditure.dto.ExpenditureCreateRequest;
+import com.mojh.dailybudget.expenditure.dto.ExpenditureUpdateRequest;
 import com.mojh.dailybudget.expenditure.repository.ExpenditureRepository;
 import com.mojh.dailybudget.member.domain.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.mojh.dailybudget.common.exception.ErrorCode.EXPENDITURE_MEMBER_MISMATCH;
+import static com.mojh.dailybudget.common.exception.ErrorCode.EXPENDITURE_NOT_FOUND;
 
 @Service
 public class ExpenditureService {
@@ -27,6 +32,18 @@ public class ExpenditureService {
         Expenditure expenditure = request.toEntity(member, category);
 
         return expenditureRepository.save(expenditure).getId();
+    }
+
+    @Transactional
+    public Boolean updateExpenditure(ExpenditureUpdateRequest request, Member member, Long expenditureId) {
+        Category category = categoryService.findByCategoryType(request.getCategory());
+        Expenditure expenditure = expenditureRepository.findById(expenditureId)
+                                                       .orElseThrow(() -> new DailyBudgetAppException(EXPENDITURE_NOT_FOUND));
+        if(!expenditure.isOwner(member)) {
+            throw new DailyBudgetAppException(EXPENDITURE_MEMBER_MISMATCH);
+        }
+
+        return expenditure.update(request.toEntity(category));
     }
 
 }

--- a/src/main/java/com/mojh/dailybudget/member/domain/Member.java
+++ b/src/main/java/com/mojh/dailybudget/member/domain/Member.java
@@ -1,6 +1,6 @@
 package com.mojh.dailybudget.member.domain;
 
-import com.mojh.dailybudget.common.entity.BaseTimeEntity;
+import com.mojh.dailybudget.common.domain.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,6 +22,10 @@ spring:
         format_sql: true
         use_sql_comments: true
 
+logging:
+  level:
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+
 jwt:
   access:
     secret-key: 'jwttokenlocaltestsecretkey1q2w3e4r!Useasecretkeyofatleast64bytesAT'

--- a/src/test/java/com/mojh/dailybudget/common/domain/PatchableFieldUtilTest.java
+++ b/src/test/java/com/mojh/dailybudget/common/domain/PatchableFieldUtilTest.java
@@ -1,0 +1,197 @@
+package com.mojh.dailybudget.common.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class PatchableFieldUtilTest {
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public class SuperObj {
+        private Boolean superNonPatchableField;
+
+        @Patchable
+        private String superPatchableIgnoreNullTrueField;
+
+        @Patchable(ignoreNull = false)
+        private Long superPatchableIgnoreNullFalseField;
+
+        public SuperObj(Boolean superNonPatchableField, String superPatchableIgnoreNullTrueField,
+                        Long superPatchableIgnoreNullFalseField) {
+            this.superNonPatchableField = superNonPatchableField;
+            this.superPatchableIgnoreNullTrueField = superPatchableIgnoreNullTrueField;
+            this.superPatchableIgnoreNullFalseField = superPatchableIgnoreNullFalseField;
+        }
+    }
+
+    @Getter
+    public class SubObj extends SuperObj {
+        private Boolean nonPatchableField;
+
+        @Patchable
+        private String patchableIgnoreNullTrueField;
+
+        @Patchable(ignoreNull = false)
+        private Long patchableIgnoreNullFalseField;
+
+        public SubObj(Boolean nonPatchableField, String patchableIgnoreNullTrueField, Long patchableIgnoreNullFalseField) {
+            this.nonPatchableField = nonPatchableField;
+            this.patchableIgnoreNullTrueField = patchableIgnoreNullTrueField;
+            this.patchableIgnoreNullFalseField = patchableIgnoreNullFalseField;
+        }
+
+        public SubObj(Boolean superNonPatchableField, String superPatchableIgnoreNullTrueField, Long superPatchableIgnoreNullFalseField,
+                      Boolean nonPatchableField, String patchableIgnoreNullTrueField, Long patchableIgnoreNullFalseField) {
+            super(superNonPatchableField, superPatchableIgnoreNullTrueField, superPatchableIgnoreNullFalseField);
+            this.nonPatchableField = nonPatchableField;
+            this.patchableIgnoreNullTrueField = patchableIgnoreNullTrueField;
+            this.patchableIgnoreNullFalseField = patchableIgnoreNullFalseField;
+        }
+    }
+
+    @Test
+    @DisplayName("patch는 변경 가능하지 않은 필드는 변경할 수 없다.")
+    void patch_nonPatchableField_false() {
+        // given
+        SuperObj oldObj = new SuperObj(false, "string", 100L);
+        SuperObj newObj = new SuperObj(true, "string", 100L);
+
+        // when
+        boolean result = PatchableFieldUtil.patch(oldObj, newObj);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("patch는 super calss의 변경 가능한 필드도 변경할 수 있다.")
+    void patch_patchableSuperClassField_true() {
+        // given
+        SuperObj oldObj = new SubObj(false, "oldSuperField", 1L,
+                false, "sub", 10L);
+        SuperObj newObj = new SubObj(true, "newSuperField", 500L,
+                false, "sub", 10L);
+
+        // when
+        boolean result = PatchableFieldUtil.patch(oldObj, newObj);
+
+        // then
+        Assertions.assertAll(
+                () -> assertThat(result).isTrue(),
+                () -> assertThat(oldObj.superNonPatchableField).isEqualTo(false),
+                () -> assertThat(oldObj.superPatchableIgnoreNullTrueField)
+                        .isEqualTo(newObj.superPatchableIgnoreNullTrueField),
+                () -> assertThat(oldObj.superPatchableIgnoreNullFalseField)
+                        .isEqualTo(newObj.superPatchableIgnoreNullFalseField)
+        );
+    }
+
+
+    @Test
+    @DisplayName("patch는 null 변경 요청을 무시하는 변경 가능한 필드와 null이 아닌 요청 데이터와 다를 때 필드를 변경한다.")
+    void patch_patchableIgnoreNullTrue_requestNotNull_requestNotEqualTarget_true() {
+        // given
+        SuperObj oldObj = new SuperObj(false, "old", 100L);
+        SuperObj newObj = new SuperObj(false, "new", 100L);
+
+        // when
+        boolean result = PatchableFieldUtil.patch(oldObj, newObj);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("patch는 null 변경 요청을 무시하는 변경 가능한 필드와 null이 아닌 요청 데이터와 같을 때 필드를 변경하지 않는다.")
+    void patch_patchableIgnoreNullTrue_requestNotNull_requestEqualTarget_false() {
+        // given
+        SuperObj oldObj = new SuperObj(false, "old", 100L);
+        SuperObj newObj = new SuperObj(false, "old", 100L);
+
+        // when
+        boolean result = PatchableFieldUtil.patch(oldObj, newObj);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("patch는 null 변경 요청을 무시하는 변경 가능한 필드를 변경할 때 요청 데이터가 null이면 필드를 변경하지 않는다.")
+    void patch_patchableIgnoreNullTrue_requestNull_false() {
+        SuperObj oldObj = new SuperObj(false, "old", 100L);
+        SuperObj newObj = new SuperObj(false, null, 100L);
+
+        boolean result = PatchableFieldUtil.patch(oldObj, newObj);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("patch는 null 변경 요청을 허용하는 변경 가능한 필드와 null이 아닌 요청 데이터와 다를 때 필드를 변경한다.")
+    void patch_patchableIgnoreNullFalse_requestNotNull_requestNotEqualTarget_true() {
+        // given
+        SuperObj oldObj = new SuperObj(false, "string", 1L);
+        SuperObj newObj = new SuperObj(false, "string", 100L);
+
+        // when
+        boolean result = PatchableFieldUtil.patch(oldObj, newObj);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("patch는 null 변경 요청을 허용하는 변경 가능한 필드와 null이 아닌 요청 데이터와 같을 때 필드를 변경하지 않는다.")
+    void patch_patchableIgnoreNullFalse_requestNotNull_requestEqualTarget_false() {
+        // given
+        SuperObj oldObj = new SuperObj(false, "string", 1L);
+        SuperObj newObj = new SuperObj(false, "string", 1L);
+
+        // when
+        boolean result = PatchableFieldUtil.patch(oldObj, newObj);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("patch는 null 변경 요청을 허용하는 변경 가능한 필드가 null이 아니고 요청 데이터가 null일 때 필드를 변경한다.")
+    void patch_patchableIgnoreNullFalse_requestNull_targetNotNull_true() {
+        SuperObj oldObj = new SuperObj(false, "string", 1L);
+        SuperObj newObj = new SuperObj(false, "string", null);
+
+        boolean result = PatchableFieldUtil.patch(oldObj, newObj);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("patch는 null 변경 요청을 허용하는 변경 가능한 필드가 null이고 요청 데이터도 null일 때 필드를 변경하지 않는다.")
+    void patch_patchableIgnoreNullFalse_requestNull_targetNull_false() {
+        SuperObj oldObj = new SuperObj(false, "string", null);
+        SuperObj newObj = new SuperObj(false, "string", null);
+
+        boolean result = PatchableFieldUtil.patch(oldObj, newObj);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("patch는 null 변경 요청을 허용하는 변경 가능한 필드가 null이고 요청 데이터는 null이 아닐 때 필드를 변경한다.")
+    void patch_patchableIgnoreNullFalse_requestNotNull_targetNull_true() {
+        SuperObj oldObj = new SuperObj(false, "string", null);
+        SuperObj newObj = new SuperObj(false, "string", 100L);
+
+        boolean result = PatchableFieldUtil.patch(oldObj, newObj);
+
+        assertThat(result).isTrue();
+    }
+
+}

--- a/src/test/java/com/mojh/dailybudget/expenditure/service/ExpenditureServiceMockTest.java
+++ b/src/test/java/com/mojh/dailybudget/expenditure/service/ExpenditureServiceMockTest.java
@@ -1,0 +1,160 @@
+package com.mojh.dailybudget.expenditure.service;
+
+import com.mojh.dailybudget.category.domain.Category;
+import com.mojh.dailybudget.category.domain.CategoryType;
+import com.mojh.dailybudget.category.service.CategorySerivce;
+import com.mojh.dailybudget.common.exception.DailyBudgetAppException;
+import com.mojh.dailybudget.common.exception.ErrorCode;
+import com.mojh.dailybudget.expenditure.domain.Expenditure;
+import com.mojh.dailybudget.expenditure.dto.ExpenditureUpdateRequest;
+import com.mojh.dailybudget.expenditure.repository.ExpenditureRepository;
+import com.mojh.dailybudget.member.domain.Member;
+import com.mojh.dailybudget.member.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("지출 서비스 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+class ExpenditureServiceMockTest {
+
+    @Mock
+    ExpenditureRepository expenditureRepository;
+
+    @Mock
+    CategorySerivce categorySerivce;
+
+    @InjectMocks
+    ExpenditureService expenditureService;
+
+    Member member;
+    Category category;
+    Expenditure oldExpenditure;
+
+    @BeforeEach
+    void setup() {
+        member = MemberFixture.MEMBER1();
+        category = new Category(CategoryType.FOOD);
+        oldExpenditure = Expenditure.builder()
+                                    .member(member)
+                                    .category(category)
+                                    .amount(20000L)
+                                    .memo("BBQ 치킨")
+                                    .excludeFromTotal(false)
+                                    .expenditureAt(LocalDateTime.of(2023, 11, 20, 20, 30))
+                                    .build();
+
+        ReflectionTestUtils.setField(oldExpenditure, "id", 1L);
+    }
+
+    private Expenditure captureExpenditure(Expenditure expenditure) {
+        return Expenditure.builder()
+                          .category(expenditure.getCategory())
+                          .amount(expenditure.getAmount())
+                          .memo(expenditure.getMemo())
+                          .excludeFromTotal(expenditure.getExcludeFromTotal())
+                          .expenditureAt(expenditure.getExpenditureAt())
+                          .build();
+    }
+
+    @Test
+    @DisplayName("지출 정보를 수정할 때 수정 요청한 필드만 변경한다.")
+    void updateExpenditure_patch_true() {
+        // given: 카테고리, 금액, 메모 변경 요청하도록 설정, 카테고리는 기존 값과 동일
+        Long expenditureId = oldExpenditure.getId();
+        Category capturedCategory = oldExpenditure.getCategory();
+        boolean capturedExcludeFromTotal = oldExpenditure.getExcludeFromTotal();
+        LocalDateTime capturedExpenditureAt = oldExpenditure.getExpenditureAt();
+        ExpenditureUpdateRequest requet = ExpenditureUpdateRequest.builder()
+                                                                  .category(CategoryType.FOOD)
+                                                                  .amount(25000L)
+                                                                  .memo("BBQ 치킨과 치즈볼")
+                                                                  .build();
+        given(categorySerivce.findByCategoryType(requet.getCategory())).willReturn(category);
+        given(expenditureRepository.findById(expenditureId)).willReturn(Optional.of(oldExpenditure));
+
+        // when
+        boolean result = expenditureService.updateExpenditure(requet, member, expenditureId);
+
+        // then: category는 기존의 값과 같았고, 지출 일시와 합계 제외는 수정 요청을 하지 않아서 변경되지 않는다.
+        // 수정 요청한 금액과 메모만 변경됨.
+        assertAll(
+                () -> assertThat(result).isTrue(),
+                () -> assertThat(oldExpenditure.getCategory()).isEqualTo(capturedCategory),
+                () -> assertThat(oldExpenditure.getAmount()).isEqualTo(requet.getAmount()),
+                () -> assertThat(oldExpenditure.getMemo()).isEqualTo(requet.getMemo()),
+                () -> assertThat(oldExpenditure.getExcludeFromTotal()).isEqualTo(capturedExcludeFromTotal),
+                () -> assertThat(oldExpenditure.getExpenditureAt()).isEqualTo(capturedExpenditureAt),
+                () -> verify(categorySerivce).findByCategoryType(requet.getCategory()),
+                () -> verify(expenditureRepository).findById(expenditureId)
+        );
+    }
+
+    @Test
+    @DisplayName("지출 정보를 수정할 때 변경할 필드가 없으면 요청이 실패한 것은 아니나 patch 결과는 false.")
+    void updateExpenditure_patch_false() {
+        // given: 카테고리 수정 요청을 했지만 기존의 값과 같을 때 변경할 필드 없음
+        Long expenditureId = oldExpenditure.getId();
+        Expenditure captured = captureExpenditure(oldExpenditure);
+        ExpenditureUpdateRequest requet = ExpenditureUpdateRequest.builder()
+                                                                  .category(CategoryType.FOOD)
+                                                                  .build();
+        given(categorySerivce.findByCategoryType(requet.getCategory())).willReturn(category);
+        given(expenditureRepository.findById(expenditureId)).willReturn(Optional.of(oldExpenditure));
+
+        // when
+        boolean result = expenditureService.updateExpenditure(requet, member, expenditureId);
+
+        // then: 카테고리는 기존 값과 변경 요청값이 동일하고, 이외의 필드는 수정 요청을 하지 않아 변경한 필드가 없음
+        assertAll(
+                () -> assertThat(result).isFalse(),
+                () -> assertThat(oldExpenditure.getCategory()).isEqualTo(captured.getCategory()),
+                () -> assertThat(oldExpenditure.getAmount()).isEqualTo(captured.getAmount()),
+                () -> assertThat(oldExpenditure.getMemo()).isEqualTo(captured.getMemo()),
+                () -> assertThat(oldExpenditure.getExcludeFromTotal()).isEqualTo(captured.getExcludeFromTotal()),
+                () -> assertThat(oldExpenditure.getExpenditureAt()).isEqualTo(captured.getExpenditureAt()),
+                () -> verify(categorySerivce).findByCategoryType(requet.getCategory()),
+                () -> verify(expenditureRepository).findById(expenditureId)
+        );
+    }
+
+    @Test
+    @DisplayName("내가 작성하지 않은 다른 사람의 지출 정보를 수정할 때 EXPENDITURE_MEMBER_MISMATCH 예외가 발생한다.")
+    void updateExpenditure_throw_expenditureMemberMismatch() {
+        // given:
+        Long expenditureId = oldExpenditure.getId();
+        Member otherMember = MemberFixture.MEMBER2();
+        ExpenditureUpdateRequest requet = ExpenditureUpdateRequest.builder()
+                                                                  .category(CategoryType.FOOD)
+                                                                  .amount(30000L)
+                                                                  .build();
+        given(categorySerivce.findByCategoryType(requet.getCategory())).willReturn(category);
+        given(expenditureRepository.findById(expenditureId)).willReturn(Optional.of(oldExpenditure));
+
+        // when
+        DailyBudgetAppException ex = assertThrows(DailyBudgetAppException.class, () -> {
+            expenditureService.updateExpenditure(requet, otherMember, expenditureId);
+        });
+
+        // then
+        assertAll(
+                () -> verify(categorySerivce).findByCategoryType(requet.getCategory()),
+                () -> verify(expenditureRepository).findById(expenditureId),
+                () -> assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.EXPENDITURE_MEMBER_MISMATCH)
+        );
+    }
+}

--- a/src/test/java/com/mojh/dailybudget/member/fixture/MemberFixture.java
+++ b/src/test/java/com/mojh/dailybudget/member/fixture/MemberFixture.java
@@ -1,0 +1,30 @@
+package com.mojh.dailybudget.member.fixture;
+
+import com.mojh.dailybudget.member.domain.Member;
+import com.mojh.dailybudget.member.domain.Role;
+
+public final class MemberFixture {
+
+    public static Member MEMBER1() {
+        return Member.builder()
+                     .accountId("member1")
+                     .password("$2a$10$x6a5r29ElOc5nThogQozT.ZZijwjZKEODkl52ayATgVtMm5gbe4Zy")
+                     .role(Role.ROLE_USER)
+                     .name("홍길동")
+                     .allowDailyBudgetNotification(false)
+                     .allowDailyExpenditureNotification(false)
+                     .build();
+    }
+
+    public static Member MEMBER2() {
+        return Member.builder()
+                     .accountId("member2")
+                     .password("$2a$10$559fNXUZW3MFH2IUEACAn.Xm.LXnPHs25rySDLbj1oxKQ2VAavIEu")
+                     .role(Role.ROLE_USER)
+                     .name("김철수")
+                     .allowDailyBudgetNotification(false)
+                     .allowDailyExpenditureNotification(false)
+                     .build();
+    }
+
+}


### PR DESCRIPTION
## 📃 설명

- resolves #11 
- 

## 🔨 작업 내용

1. 변경 가능한 필드에 적용할 annotation과 수정 작업 처리할 util class 추가
   - entity 마다 데이터 수정 로직에 사용될 요청 데이터 null 체크 등의 로직 중복 방지
2. PatchableFieldUtil의 patch 함수 테스트 작성
3. 필요한데 빠진 내용 추가
   - lombok 테스트 관련 의존성 빠진 것 추가
   - 지출 entity에서 extends BaseTimeEntity 빠진 것 추가
   - 지출 생성 요청 dto에서 지출 일시 not null 체크 빠진 것 추가
4. 지출 수정 API 구현
5. 지출 수정 서비스 단위 테스트 작성

## 💬 기타 사항

1. ReflectionUtils `public static void doWithFields(Class<?> clazz, FieldCallback fc, @Nullable FieldFilter ff)`
   - 대상 클래스의 모든 필드에 대해 지정된 Callback 호출
   - 클래스 계층을 올라가 모든 선언된 필드를 얻어옴
   - `ff` 필터에 해당하는 필드만 Callback 호출
2. 작업 내용 1번 관련 [링크](https://blog.gangnamunni.com/post/Annotation-Reflection-Entity-update/)