### PR TITLE
feat: 지출 삭제 API 구현

### DIFF
--- a/src/main/java/com/mojh/dailybudget/budget/domain/Budget.java
+++ b/src/main/java/com/mojh/dailybudget/budget/domain/Budget.java
@@ -35,10 +35,10 @@ public class Budget extends BaseTimeEntity {
     private Member member;
 
     @Column(nullable = false)
-    private Integer year;
+    private Integer budgetYear;
 
     @Column(nullable = false)
-    private Integer month;
+    private Integer budgetMonth;
 
     @Column(nullable = false)
     private Long totalAmount;
@@ -47,11 +47,11 @@ public class Budget extends BaseTimeEntity {
     private List<BudgetCategory> budgetCategoryList = new ArrayList<>();
 
     @Builder
-    public Budget(Member member, Integer year, Integer month,
+    public Budget(Member member, Integer budgetYear, Integer budgetMonth,
                   Long totalAmount, List<BudgetCategory> budgetCategoryList) {
         this.member = member;
-        this.year = year;
-        this.month = month;
+        this.budgetYear = budgetYear;
+        this.budgetMonth = budgetMonth;
         this.totalAmount = totalAmount;
         this.budgetCategoryList = budgetCategoryList;
     }

--- a/src/main/java/com/mojh/dailybudget/budget/repository/BudgetRepository.java
+++ b/src/main/java/com/mojh/dailybudget/budget/repository/BudgetRepository.java
@@ -8,6 +8,6 @@ import java.util.Optional;
 
 public interface BudgetRepository extends JpaRepository<Budget, Long> {
 
-    Optional<Budget> findByMemberAndYearAndMonth(Member member, Integer year, Integer month);
+    Optional<Budget> findByMemberAndBudgetYearAndBudgetMonth(Member member, Integer budgetYear, Integer budgetMonth);
 
 }

--- a/src/main/java/com/mojh/dailybudget/budget/service/BudgetService.java
+++ b/src/main/java/com/mojh/dailybudget/budget/service/BudgetService.java
@@ -4,7 +4,6 @@ import com.mojh.dailybudget.budget.domain.Budget;
 import com.mojh.dailybudget.budget.domain.BudgetCategory;
 import com.mojh.dailybudget.budget.dto.BudgetPutRequest;
 import com.mojh.dailybudget.budget.dto.BudgetPutRequest.BudgetCategoryRequest;
-import com.mojh.dailybudget.budget.repository.BudgetCategoryRepository;
 import com.mojh.dailybudget.budget.repository.BudgetRepository;
 import com.mojh.dailybudget.category.domain.CategoryType;
 import com.mojh.dailybudget.common.exception.DailyBudgetAppException;
@@ -43,7 +42,7 @@ public class BudgetService {
         }
 
         Optional<Budget> optionalBudget =
-                budgetRepository.findByMemberAndYearAndMonth(member, request.getYear(), request.getMonth());
+                budgetRepository.findByMemberAndBudgetYearAndBudgetMonth(member, request.getYear(), request.getMonth());
 
         // replace
         if (optionalBudget.isPresent()) {
@@ -70,8 +69,8 @@ public class BudgetService {
 
         Budget budget = Budget.builder()
                               .member(member)
-                              .year(request.getYear())
-                              .month(request.getMonth())
+                              .budgetYear(request.getYear())
+                              .budgetMonth(request.getMonth())
                               .totalAmount(totalAmount)
                               .budgetCategoryList(budgetCategoryList)
                               .build();

--- a/src/main/java/com/mojh/dailybudget/common/exception/ErrorCode.java
+++ b/src/main/java/com/mojh/dailybudget/common/exception/ErrorCode.java
@@ -30,13 +30,12 @@ public enum ErrorCode {
     ALREADY_LOGGED_OUT(UNAUTHORIZED, "AUTH0004", "이미 로그아웃 처리된 유저입니다."),
     LOGIN_FAILED(BAD_REQUEST, "AUTH0005", "아이디 혹은 비밀번호가 일치하지 않습니다."),
 
-
     // budget
     TOTAL_BUDGET_LIMIT_EXCESS(BAD_REQUEST, "BUD0001", "총 예산은 1조원을 초과하여 설정할 수 없습니다."),
 
     // expenditure
     EXPENDITURE_NOT_FOUND(NOT_FOUND, "EXP0001", "지출 정보를 찾을 수 없습니다."),
-    EXPENDITURE_MEMBER_MISMATCH(BAD_REQUEST, "EXP0002", "해당 지출 정보를 작성한 유저와 다릅니다."),
+    EXPENDITURE_MEMBER_MISMATCH(BAD_REQUEST, "EXP0002", "해당 지출 정보를 작성한 유저가 아닙니다."),
 
     // category
     CATEGORY_NOT_FOUND(NOT_FOUND, "CATE0001", "카테고리를 찾을 수 없습니다.")

--- a/src/main/java/com/mojh/dailybudget/expenditure/controller/ExpenditureController.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/controller/ExpenditureController.java
@@ -8,6 +8,7 @@ import com.mojh.dailybudget.expenditure.service.ExpenditureService;
 import com.mojh.dailybudget.member.domain.Member;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -51,5 +52,11 @@ public class ExpenditureController {
         return ApiResponse.succeed(updated);
     }
 
+    @DeleteMapping("/{expenditureId}")
+    public ResponseEntity deleteExpenditure(@LoginMember final Member member,
+                                            @PathVariable Long expenditureId) {
+        expenditureService.deleteExpenditure(member, expenditureId);
+        return ResponseEntity.noContent().build();
+    }
 
 }

--- a/src/main/java/com/mojh/dailybudget/expenditure/domain/Expenditure.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/domain/Expenditure.java
@@ -45,7 +45,7 @@ public class Expenditure extends BaseTimeEntity {
     private Long amount;
 
     @Patchable
-    @Column(nullable = false, columnDefinition = "char", length = 40)
+    @Column(nullable = false, columnDefinition = "char(40)")
     private String memo;
 
     @Patchable

--- a/src/main/java/com/mojh/dailybudget/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/service/ExpenditureService.java
@@ -46,4 +46,16 @@ public class ExpenditureService {
         return expenditure.update(request.toEntity(category));
     }
 
+    @Transactional
+    public void deleteExpenditure(Member member, Long expenditureId) {
+        Expenditure expenditure = expenditureRepository.findById(expenditureId)
+                                                       .orElseThrow(() -> new DailyBudgetAppException(EXPENDITURE_NOT_FOUND));
+
+        if(!expenditure.isOwner(member)) {
+            throw new DailyBudgetAppException(EXPENDITURE_MEMBER_MISMATCH);
+        }
+
+        expenditureRepository.delete(expenditure);
+    }
+
 }

--- a/src/test/java/com/mojh/dailybudget/auth/fixture/JwtFixture.java
+++ b/src/test/java/com/mojh/dailybudget/auth/fixture/JwtFixture.java
@@ -1,0 +1,13 @@
+package com.mojh.dailybudget.auth.fixture;
+
+public final class JwtFixture {
+
+    public final static String ACCESS_TOKEN_MEMBER1 = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9" +
+            ".eyJzdWIiOiJtZW1iZXIxIiwiaWF0IjoxNzAwNjk3MzYyLCJleHAiOjMyNTAzNTYxMjAwfQ" +
+            ".LDr1XUH47z7CTCPIaMdz-yh9FF8JUtU-YM0Pz7OvJQs5GuMsn1TjYHTqayO67zQvQB6nUMnrdG7c7axxZzvfPQ";
+
+    public final static String ACCESS_TOKEN_MEMBER2 = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9" +
+            ".eyJzdWIiOiJtZW1iZXIyIiwiaWF0IjoxNzAwNjk3NDQ3LCJleHAiOjMyNTAzNTYxMjAwfQ" +
+            ".j2JW6uyoWvZZW4D33KNOirAgDhYGLtjt4qugJKEGSUJfuI0bMQVDsij020qtK2KdQSbE8BKabUsdK44jKXgVgw";
+
+}

--- a/src/test/java/com/mojh/dailybudget/expenditure/controller/ExpenditureControllerTest.java
+++ b/src/test/java/com/mojh/dailybudget/expenditure/controller/ExpenditureControllerTest.java
@@ -1,0 +1,105 @@
+package com.mojh.dailybudget.expenditure.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mojh.dailybudget.auth.fixture.JwtFixture;
+import com.mojh.dailybudget.common.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.mojh.dailybudget.common.exception.ErrorCode.EXPENDITURE_MEMBER_MISMATCH;
+import static com.mojh.dailybudget.common.exception.ErrorCode.EXPENDITURE_NOT_FOUND;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Sql("/db/member-expenditure.sql")
+@DisplayName("지출 API 통합 테스트")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class ExpenditureControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    private final String url = "/api/expenditures";
+    private final String deleteURL = url + "/{expenditureId}";
+
+    @Test
+    @DisplayName("지출 삭제 성공")
+    void deleteExpenditure() throws Exception {
+        // given
+        Long expenditrueId = 1L;
+        String accessToken = JwtFixture.ACCESS_TOKEN_MEMBER1;
+
+        // when, then
+        mockMvc.perform(delete(deleteURL, expenditrueId)
+                       .header(AUTHORIZATION, accessToken))
+               .andDo(print())
+               .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("존재하지 않은 지출 정보를 삭제할 때 EXPENDITURE_NOT_FOUND 예외가 발생한다.")
+    void deleteExpenditure_throw_expenditureNotFound() throws Exception {
+        // given
+        Long expenditrueId = 2342345L;
+        String accessToken = JwtFixture.ACCESS_TOKEN_MEMBER1;
+        ErrorCode expected = EXPENDITURE_NOT_FOUND;
+
+        // when, then
+        mockMvc.perform(delete(deleteURL, expenditrueId)
+                       .header(AUTHORIZATION, accessToken))
+               .andDo(print())
+               .andExpect(status().isNotFound())
+               .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+               .andExpect(jsonPath("$.success").value(false))
+               .andExpect(jsonPath("$.response").doesNotExist())
+               .andExpect(jsonPath("$.error.code").value(expected.getCode()))
+               .andExpect(jsonPath("$.error.message").value(expected.getMessage()));
+    }
+
+    @Test
+    @DisplayName("내가 작성하지 않은 다른 유저의 지출 정보를 삭제할 때 EXPENDITURE_MEMBER_MISMATCH 예외가 발생한다.")
+    void deleteExpenditure_throw_expenditureMemberMismatch() throws Exception {
+        // given: member1이 만든 지출 정보를 member2가 삭제하도록 설정
+        Long expenditrueId = 1L;
+        String accessTokenMember2 = JwtFixture.ACCESS_TOKEN_MEMBER2;
+        ErrorCode expected = EXPENDITURE_MEMBER_MISMATCH;
+
+        // when, then
+        mockMvc.perform(delete(deleteURL, expenditrueId)
+                       .header(AUTHORIZATION, accessTokenMember2))
+               .andDo(print())
+               .andExpect(status().isBadRequest())
+               .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+               .andExpect(jsonPath("$.success").value(false))
+               .andExpect(jsonPath("$.response").doesNotExist())
+               .andExpect(jsonPath("$.error.code").value(expected.getCode()))
+               .andExpect(jsonPath("$.error.message").value(expected.getMessage()));
+    }
+
+    /*
+    private final boolean success;
+    private final T response;
+    private final ErrorResponse<?> error;
+     */
+
+
+
+}

--- a/src/test/java/com/mojh/dailybudget/expenditure/service/ExpenditureServiceMockTest.java
+++ b/src/test/java/com/mojh/dailybudget/expenditure/service/ExpenditureServiceMockTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @DisplayName("지출 서비스 단위 테스트")
@@ -43,22 +44,22 @@ class ExpenditureServiceMockTest {
 
     Member member;
     Category category;
-    Expenditure oldExpenditure;
+    Expenditure expenditure;
 
     @BeforeEach
     void setup() {
         member = MemberFixture.MEMBER1();
         category = new Category(CategoryType.FOOD);
-        oldExpenditure = Expenditure.builder()
-                                    .member(member)
-                                    .category(category)
-                                    .amount(20000L)
-                                    .memo("BBQ 치킨")
-                                    .excludeFromTotal(false)
-                                    .expenditureAt(LocalDateTime.of(2023, 11, 20, 20, 30))
-                                    .build();
+        expenditure = Expenditure.builder()
+                                 .member(member)
+                                 .category(category)
+                                 .amount(20000L)
+                                 .memo("BBQ 치킨")
+                                 .excludeFromTotal(false)
+                                 .expenditureAt(LocalDateTime.of(2023, 11, 20, 20, 30))
+                                 .build();
 
-        ReflectionTestUtils.setField(oldExpenditure, "id", 1L);
+        ReflectionTestUtils.setField(expenditure, "id", 1L);
     }
 
     private Expenditure captureExpenditure(Expenditure expenditure) {
@@ -75,17 +76,17 @@ class ExpenditureServiceMockTest {
     @DisplayName("지출 정보를 수정할 때 수정 요청한 필드만 변경한다.")
     void updateExpenditure_patch_true() {
         // given: 카테고리, 금액, 메모 변경 요청하도록 설정, 카테고리는 기존 값과 동일
-        Long expenditureId = oldExpenditure.getId();
-        Category capturedCategory = oldExpenditure.getCategory();
-        boolean capturedExcludeFromTotal = oldExpenditure.getExcludeFromTotal();
-        LocalDateTime capturedExpenditureAt = oldExpenditure.getExpenditureAt();
+        Long expenditureId = expenditure.getId();
+        Category capturedCategory = expenditure.getCategory();
+        boolean capturedExcludeFromTotal = expenditure.getExcludeFromTotal();
+        LocalDateTime capturedExpenditureAt = expenditure.getExpenditureAt();
         ExpenditureUpdateRequest requet = ExpenditureUpdateRequest.builder()
                                                                   .category(CategoryType.FOOD)
                                                                   .amount(25000L)
                                                                   .memo("BBQ 치킨과 치즈볼")
                                                                   .build();
         given(categorySerivce.findByCategoryType(requet.getCategory())).willReturn(category);
-        given(expenditureRepository.findById(expenditureId)).willReturn(Optional.of(oldExpenditure));
+        given(expenditureRepository.findById(expenditureId)).willReturn(Optional.of(expenditure));
 
         // when
         boolean result = expenditureService.updateExpenditure(requet, member, expenditureId);
@@ -94,11 +95,11 @@ class ExpenditureServiceMockTest {
         // 수정 요청한 금액과 메모만 변경됨.
         assertAll(
                 () -> assertThat(result).isTrue(),
-                () -> assertThat(oldExpenditure.getCategory()).isEqualTo(capturedCategory),
-                () -> assertThat(oldExpenditure.getAmount()).isEqualTo(requet.getAmount()),
-                () -> assertThat(oldExpenditure.getMemo()).isEqualTo(requet.getMemo()),
-                () -> assertThat(oldExpenditure.getExcludeFromTotal()).isEqualTo(capturedExcludeFromTotal),
-                () -> assertThat(oldExpenditure.getExpenditureAt()).isEqualTo(capturedExpenditureAt),
+                () -> assertThat(expenditure.getCategory()).isEqualTo(capturedCategory),
+                () -> assertThat(expenditure.getAmount()).isEqualTo(requet.getAmount()),
+                () -> assertThat(expenditure.getMemo()).isEqualTo(requet.getMemo()),
+                () -> assertThat(expenditure.getExcludeFromTotal()).isEqualTo(capturedExcludeFromTotal),
+                () -> assertThat(expenditure.getExpenditureAt()).isEqualTo(capturedExpenditureAt),
                 () -> verify(categorySerivce).findByCategoryType(requet.getCategory()),
                 () -> verify(expenditureRepository).findById(expenditureId)
         );
@@ -108,13 +109,13 @@ class ExpenditureServiceMockTest {
     @DisplayName("지출 정보를 수정할 때 변경할 필드가 없으면 요청이 실패한 것은 아니나 patch 결과는 false.")
     void updateExpenditure_patch_false() {
         // given: 카테고리 수정 요청을 했지만 기존의 값과 같을 때 변경할 필드 없음
-        Long expenditureId = oldExpenditure.getId();
-        Expenditure captured = captureExpenditure(oldExpenditure);
+        Long expenditureId = expenditure.getId();
+        Expenditure captured = captureExpenditure(expenditure);
         ExpenditureUpdateRequest requet = ExpenditureUpdateRequest.builder()
                                                                   .category(CategoryType.FOOD)
                                                                   .build();
         given(categorySerivce.findByCategoryType(requet.getCategory())).willReturn(category);
-        given(expenditureRepository.findById(expenditureId)).willReturn(Optional.of(oldExpenditure));
+        given(expenditureRepository.findById(expenditureId)).willReturn(Optional.of(expenditure));
 
         // when
         boolean result = expenditureService.updateExpenditure(requet, member, expenditureId);
@@ -122,11 +123,11 @@ class ExpenditureServiceMockTest {
         // then: 카테고리는 기존 값과 변경 요청값이 동일하고, 이외의 필드는 수정 요청을 하지 않아 변경한 필드가 없음
         assertAll(
                 () -> assertThat(result).isFalse(),
-                () -> assertThat(oldExpenditure.getCategory()).isEqualTo(captured.getCategory()),
-                () -> assertThat(oldExpenditure.getAmount()).isEqualTo(captured.getAmount()),
-                () -> assertThat(oldExpenditure.getMemo()).isEqualTo(captured.getMemo()),
-                () -> assertThat(oldExpenditure.getExcludeFromTotal()).isEqualTo(captured.getExcludeFromTotal()),
-                () -> assertThat(oldExpenditure.getExpenditureAt()).isEqualTo(captured.getExpenditureAt()),
+                () -> assertThat(expenditure.getCategory()).isEqualTo(captured.getCategory()),
+                () -> assertThat(expenditure.getAmount()).isEqualTo(captured.getAmount()),
+                () -> assertThat(expenditure.getMemo()).isEqualTo(captured.getMemo()),
+                () -> assertThat(expenditure.getExcludeFromTotal()).isEqualTo(captured.getExcludeFromTotal()),
+                () -> assertThat(expenditure.getExpenditureAt()).isEqualTo(captured.getExpenditureAt()),
                 () -> verify(categorySerivce).findByCategoryType(requet.getCategory()),
                 () -> verify(expenditureRepository).findById(expenditureId)
         );
@@ -135,15 +136,15 @@ class ExpenditureServiceMockTest {
     @Test
     @DisplayName("내가 작성하지 않은 다른 사람의 지출 정보를 수정할 때 EXPENDITURE_MEMBER_MISMATCH 예외가 발생한다.")
     void updateExpenditure_throw_expenditureMemberMismatch() {
-        // given:
-        Long expenditureId = oldExpenditure.getId();
+        // given
+        Long expenditureId = expenditure.getId();
         Member otherMember = MemberFixture.MEMBER2();
         ExpenditureUpdateRequest requet = ExpenditureUpdateRequest.builder()
                                                                   .category(CategoryType.FOOD)
                                                                   .amount(30000L)
                                                                   .build();
         given(categorySerivce.findByCategoryType(requet.getCategory())).willReturn(category);
-        given(expenditureRepository.findById(expenditureId)).willReturn(Optional.of(oldExpenditure));
+        given(expenditureRepository.findById(expenditureId)).willReturn(Optional.of(expenditure));
 
         // when
         DailyBudgetAppException ex = assertThrows(DailyBudgetAppException.class, () -> {
@@ -155,6 +156,67 @@ class ExpenditureServiceMockTest {
                 () -> verify(categorySerivce).findByCategoryType(requet.getCategory()),
                 () -> verify(expenditureRepository).findById(expenditureId),
                 () -> assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.EXPENDITURE_MEMBER_MISMATCH)
+        );
+    }
+
+    @Test
+    @DisplayName("지출 정보를 삭제한다.")
+    void deleteExpenditure_success() {
+        // given
+        Long expenditureId = expenditure.getId();
+        given(expenditureRepository.findById(expenditureId)).willReturn(Optional.of(expenditure));
+
+        // when
+        expenditureService.deleteExpenditure(member, expenditureId);
+
+        // then: category는 기존의 값과 같았고, 지출 일시와 합계 제외는 수정 요청을 하지 않아서 변경되지 않는다.
+        // 수정 요청한 금액과 메모만 변경됨.
+        assertAll(
+                () -> verify(expenditureRepository).findById(expenditureId),
+                () -> verify(expenditureRepository).delete(expenditure)
+        );
+    }
+
+    @Test
+    @DisplayName("삭제하려는 지출 정보가 없을 때 EXPENDITURE_NOT_FOUND 예외가 발생한다.")
+    void deleteExpenditure_throw_expenditureNotFound() {
+        // given
+        Long expenditureId = expenditure.getId();
+        Long otherId = 35723412L;
+        given(expenditureRepository.findById(otherId)).willReturn(Optional.empty());
+
+        // when
+        DailyBudgetAppException ex = assertThrows(DailyBudgetAppException.class, () -> {
+            expenditureService.deleteExpenditure(member, otherId);
+        });
+
+        // then
+        assertAll(
+                () -> assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.EXPENDITURE_NOT_FOUND),
+                () -> verify(expenditureRepository).findById(otherId),
+                () -> verify(expenditureRepository, never()).findById(expenditureId),
+                () -> verify(expenditureRepository, never()).delete(expenditure)
+        );
+    }
+
+    @Test
+    @DisplayName("내가 작성하지 않은 다른 유저의 지출 정보는 삭제할 때 EXPENDITURE_MEMBER_MISMATCH 예외가 발생한다.")
+    void deleteExpenditure_throw_expenditureMemberMismatch() {
+        // given
+        Long expenditureId = expenditure.getId();
+        Member otherMember = MemberFixture.MEMBER2();
+        given(expenditureRepository.findById(expenditureId)).willReturn(Optional.of(expenditure));
+
+        // when
+        DailyBudgetAppException ex = assertThrows(DailyBudgetAppException.class, () -> {
+            expenditureService.deleteExpenditure(otherMember, expenditureId);
+        });
+
+        // then
+        assertAll(
+                () -> assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.EXPENDITURE_MEMBER_MISMATCH),
+                () -> verify(expenditureRepository).findById(expenditureId),
+                () -> verify(expenditureRepository, never()).delete(expenditure)
         );
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -22,3 +22,11 @@ spring:
   h2:
     console:
       enabled: true
+
+jwt:
+  access:
+    secret-key: 'jwttokenlocaltestsecretkey1q2w3e4r!Useasecretkeyofatleast64bytesAT'
+    token-valid-time: 1800000 # 테스트용으로 30분
+  refresh:
+    secret-key: 'jwttokenlocaltestsecretkey1q2w3e4r!Useasecretkeyofatleast64bytesRT'
+    token-valid-time: 2400000 # 테스트용으로 40분

--- a/src/test/resources/db/member-expenditure.sql
+++ b/src/test/resources/db/member-expenditure.sql
@@ -1,0 +1,32 @@
+set FOREIGN_KEY_CHECKS = 0;
+TRUNCATE TABLE category;
+TRUNCATE TABLE member;
+TRUNCATE TABLE expenditure;
+set FOREIGN_KEY_CHECKS = 1;
+
+INSERT INTO category (type)
+VALUES ('FOOD'),           -- 1
+       ('TRANSPORTATION'), -- 2
+       ('SHOPPING'),       -- 3
+       ('MEDICAL'),        -- 4
+       ('EDUCATION'),      -- 5
+       ('ENTERTAINMENT'),  -- 6
+       ('FINANCE'),        -- 7
+       ('PHONE'),          -- 8
+       ('HOUSE'),          -- 9
+       ('UNCATEGORIZED'); -- 10
+
+INSERT INTO member (account_id, password, role, name, allow_daily_budget_noti,
+                    allow_daily_expenditure_noti, created_at, updated_at)
+VALUES ('member1', '$2a$10$x6a5r29ElOc5nThogQozT.ZZijwjZKEODkl52ayATgVtMm5gbe4Zy', 'ROLE_USER',
+        '홍길동', 0, 0, '2023-11-17 15:07:23', '2023-11-19 16:25:22'),
+       ('member2', '$2a$10$559fNXUZW3MFH2IUEACAn.Xm.LXnPHs25rySDLbj1oxKQ2VAavIEu', 'ROLE_USER',
+        '김철수', 0, 0, '2023-11-22 08:22:53', '2023-11-23 14:47:30');
+
+
+INSERT INTO expenditure (member_id, category_id, amount, memo, exclude_from_total,
+                         expenditure_at, created_at, updated_at)
+VALUES (1, 1, 20000, '치킨', 0, '2023-11-20 13:15:42', '2023-11-20 20:36:17', '2023-11-20 20:36:17'),
+       (1, 2, 6800, '택시비', 0, '2023-11-21 08:22:35', '2023-11-21 21:20:05', '2023-11-21 21:20:05'),
+       (2, 5, 120000, '인프런 강의 구매', 0, '2023-11-21 08:22:35', '2023-11-21 21:20:05', '2023-11-21 21:20:05'),
+       (2, 8, 49800, '23년 11월 통신비', 0, '2023-11-22 17:20:05', '2023-11-22 20:48:55', '2023-11-22 20:48:55');


### PR DESCRIPTION
## 📃 설명

- resolves #12 
- 

## 🔨 작업 내용

1. 지출 삭제 API 구현
2. 지출 삭제 서비스 단위 테스트 작성
3. 지출 삭제 컨트롤러 통합 테스트 작성
4. Budget entity 년도, 월 필드명 변경
   - `year`, `month` 필드가 h2 예약어랑 겹쳐서 문제 생김
   -  각각 앞에 `budget_` 붙이도록 변경
5. Expenditure entity memo 필드 타입 설정 변경
   - 기존의 Column annotation내에 `columnDefinition = "char", length = 40` 로만 설정했는데 char 타입 설정 되면서 길이 40으로 될 줄 알았으나 테스트 코드에서 테이블 자동 생성 시 `char` 타입으로만 생성됨
   - columnDefinition에서 `"char(40)"`으로 명시적으로 표기함

## 💬 기타 사항

- 