### PR TITLE
refactor: Enum type 유효성 검증 방법 수정

### DIFF
--- a/src/main/java/com/mojh/dailybudget/budget/dto/BudgetPutRequest.java
+++ b/src/main/java/com/mojh/dailybudget/budget/dto/BudgetPutRequest.java
@@ -9,9 +9,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Range;
 
+import javax.validation.Valid;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -25,6 +25,7 @@ public class BudgetPutRequest {
     @Range(min = 1, max = 12)
     private Integer month;
 
+    @Valid
     @ValidBudgetCategoryRequests
     private List<BudgetCategoryRequest> budgetCategoryRequests;
 
@@ -34,25 +35,24 @@ public class BudgetPutRequest {
         this.budgetCategoryRequests = budgetCategoryRequests;
     }
 
-    // TODO: static 말고 따로 dto class로 빼도 좋을듯
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class BudgetCategoryRequest {
 
-        @ValidEnum
-        private CategoryType category;
+        @ValidEnum(enumClass = CategoryType.class)
+        private String category;
 
         // TODO: max값 적절한 값으로 설정
         @Range(min = 0L, max = 1000000000000L)
         private long amount;
 
-        public BudgetCategoryRequest(CategoryType category, long amount) {
+        public BudgetCategoryRequest(String category, long amount) {
             this.category = category;
             this.amount = amount;
         }
 
         public BudgetCategory toEntity() {
-            return BudgetCategory.of(category, amount);
+            return BudgetCategory.of(CategoryType.valueOf(category), amount);
         }
 
         // equals, hashcode ide 자동 생성 이용한 코드

--- a/src/main/java/com/mojh/dailybudget/budget/service/BudgetService.java
+++ b/src/main/java/com/mojh/dailybudget/budget/service/BudgetService.java
@@ -51,7 +51,7 @@ public class BudgetService {
             // 카테고리별 예산 list -> map
             Map<CategoryType, BudgetCategoryRequest> budgetCategoryRequests =
                     request.getBudgetCategoryRequests().stream()
-                           .collect(Collectors.toMap(BudgetCategoryRequest::getCategory , Function.identity()));
+                           .collect(Collectors.toMap(req -> CategoryType.valueOf(req.getCategory()) , Function.identity()));
 
             // 카테고리별 예산 update
             for (BudgetCategory budgetCategory : budget.getBudgetCategoryList()) {

--- a/src/main/java/com/mojh/dailybudget/budget/validation/BudgetCategoryRequestsValidator.java
+++ b/src/main/java/com/mojh/dailybudget/budget/validation/BudgetCategoryRequestsValidator.java
@@ -33,7 +33,7 @@ public class BudgetCategoryRequestsValidator
         Set<CategoryType> checked = new HashSet<>();
 
         for (BudgetCategoryRequest budgetCategoryRequest : value) {
-            CategoryType currentType = budgetCategoryRequest.getCategory();
+            CategoryType currentType = CategoryType.valueOf(budgetCategoryRequest.getCategory());
 
             // 입력된 카테고리별 예산 필드 중복 확인
             if (checked.contains(currentType)) {

--- a/src/main/java/com/mojh/dailybudget/category/domain/CategoryType.java
+++ b/src/main/java/com/mojh/dailybudget/category/domain/CategoryType.java
@@ -1,21 +1,10 @@
 package com.mojh.dailybudget.category.domain;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
-
-import java.util.stream.Stream;
 
 @Getter
 public enum CategoryType {
-    FOOD, TRANSPORTATION, SHOPPING, MEDICAL, EDUCATION, ENTERTAINMENT, FINANCE, PHONE, HOUSE, UNCATEGORIZED;
 
-    @JsonCreator
-    public static CategoryType parse(String input) {
-        String inputUpperCase = input.toUpperCase();
-        return Stream.of(CategoryType.values())
-                     .filter(type -> type.toString().equals(inputUpperCase))
-                     .findFirst()
-                     .orElse(null);
-    }
+    FOOD, TRANSPORTATION, SHOPPING, MEDICAL, EDUCATION, ENTERTAINMENT, FINANCE, PHONE, HOUSE, UNCATEGORIZED;
 
 }

--- a/src/main/java/com/mojh/dailybudget/category/service/CategorySerivce.java
+++ b/src/main/java/com/mojh/dailybudget/category/service/CategorySerivce.java
@@ -26,6 +26,12 @@ public class CategorySerivce {
                          .toList();
     }
 
+    public Category findByCategoryType(String categoryType) {
+        CategoryType type = CategoryType.valueOf(categoryType);
+        return categoryRepository.findByType(type)
+                                 .orElseThrow(() -> new DailyBudgetAppException(CATEGORY_NOT_FOUND));
+    }
+
     public Category findByCategoryType(CategoryType categoryType) {
         return categoryRepository.findByType(categoryType)
                                  .orElseThrow(() -> new DailyBudgetAppException(CATEGORY_NOT_FOUND));

--- a/src/main/java/com/mojh/dailybudget/common/vaildation/EnumValidator.java
+++ b/src/main/java/com/mojh/dailybudget/common/vaildation/EnumValidator.java
@@ -1,13 +1,37 @@
 package com.mojh.dailybudget.common.vaildation;
 
+import com.mojh.dailybudget.category.domain.CategoryType;
+
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
+import java.util.Arrays;
+import java.util.stream.Stream;
 
-public class EnumValidator implements ConstraintValidator<ValidEnum, Enum<?>> {
+public class EnumValidator implements ConstraintValidator<ValidEnum, String> {
+
+    private ValidEnum annotation;
 
     @Override
-    public boolean isValid(Enum<?> value, ConstraintValidatorContext context) {
-        return value != null;
+    public void initialize(ValidEnum constraintAnnotation) {
+        annotation = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        // 필드가 null일 때 null을 허용하지 않으면 false, 허용하면 true
+        if(value == null) {
+            return annotation.allowsNull();
+        }
+
+        // 대소문자 구분 여부에 따라 처리
+        if (!annotation.caseSensitive()) {
+            value = value.toUpperCase();
+        }
+
+        // 필드가 null이 아닐 때 enum 필드와 매칭되는지 확인
+        String finalValue = value;
+        return Arrays.stream(annotation.enumClass().getEnumConstants())
+                     .anyMatch(enumValue -> enumValue.name().equals(finalValue));
     }
 
 }

--- a/src/main/java/com/mojh/dailybudget/common/vaildation/EnumValidator.java
+++ b/src/main/java/com/mojh/dailybudget/common/vaildation/EnumValidator.java
@@ -1,11 +1,8 @@
 package com.mojh.dailybudget.common.vaildation;
 
-import com.mojh.dailybudget.category.domain.CategoryType;
-
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import java.util.Arrays;
-import java.util.stream.Stream;
 
 public class EnumValidator implements ConstraintValidator<ValidEnum, String> {
 

--- a/src/main/java/com/mojh/dailybudget/common/vaildation/ValidEnum.java
+++ b/src/main/java/com/mojh/dailybudget/common/vaildation/ValidEnum.java
@@ -25,4 +25,18 @@ public @interface ValidEnum {
 
     Class<? extends Payload>[] payload() default {};
 
+    Class<? extends java.lang.Enum<?>> enumClass();
+
+    /**
+     * 해당 필드의 null 허용 여부
+     * @return 기본 값은 false
+     */
+    boolean allowsNull() default false;
+
+    /**
+     * 대소문자 구분
+     * @return 기본 값은 false으로 구분하지 않음
+     */
+    boolean caseSensitive() default false;
+
 }

--- a/src/main/java/com/mojh/dailybudget/expenditure/dto/request/ExpenditureCreateRequest.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/dto/request/ExpenditureCreateRequest.java
@@ -19,8 +19,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExpenditureCreateRequest {
 
-    @ValidEnum
-    private CategoryType category;
+    @ValidEnum(enumClass = CategoryType.class)
+    private String category;
 
     @Range(min = 0L, max = 1000000000000L)
     private Long amount;
@@ -34,7 +34,7 @@ public class ExpenditureCreateRequest {
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime expenditureAt;
 
-    public ExpenditureCreateRequest(CategoryType category, Long amount, String memo,
+    public ExpenditureCreateRequest(String category, Long amount, String memo,
                                     Boolean excludeFromTotal, LocalDateTime expenditureAt) {
         this.category = category;
         this.amount = amount;

--- a/src/main/java/com/mojh/dailybudget/expenditure/dto/request/ExpenditureUpdateRequest.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/dto/request/ExpenditureUpdateRequest.java
@@ -18,8 +18,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExpenditureUpdateRequest {
 
-    @ValidEnum
-    private CategoryType category;
+    @ValidEnum(enumClass = CategoryType.class, allowsNull = true)
+    private String category;
 
     @Range(min = 0L, max = 1000000000000L)
     private Long amount;
@@ -33,7 +33,7 @@ public class ExpenditureUpdateRequest {
     private LocalDateTime expenditureAt;
 
     @Builder
-    public ExpenditureUpdateRequest(CategoryType category, Long amount, String memo,
+    public ExpenditureUpdateRequest(String category, Long amount, String memo,
                                     Boolean excludeFromTotal, LocalDateTime expenditureAt) {
         this.category = category;
         this.amount = amount;

--- a/src/main/java/com/mojh/dailybudget/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/service/ExpenditureService.java
@@ -81,7 +81,11 @@ public class ExpenditureService {
 
     @Transactional
     public Boolean updateExpenditure(ExpenditureUpdateRequest request, Member member, Long expenditureId) {
-        Category category = categoryService.findByCategoryType(request.getCategory());
+        Category category = null;
+        if (request.getCategory() != null) {
+            category = categoryService.findByCategoryType(request.getCategory());
+        }
+
         Expenditure expenditure = expenditureRepository.findById(expenditureId)
                                                        .orElseThrow(() -> new DailyBudgetAppException(EXPENDITURE_NOT_FOUND));
         if (!expenditure.isOwner(member)) {

--- a/src/main/java/com/mojh/dailybudget/member/domain/Role.java
+++ b/src/main/java/com/mojh/dailybudget/member/domain/Role.java
@@ -1,19 +1,6 @@
 package com.mojh.dailybudget.member.domain;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-
-import java.util.stream.Stream;
 
 public enum Role {
     ROLE_USER;
-
-    @JsonCreator
-    public static Role parse(String input) {
-        String inputUpperCase = input.toUpperCase();
-        return Stream.of(Role.values())
-                     .filter(role -> role.toString().equals(inputUpperCase))
-                     .findFirst()
-                     .orElse(null);
-    }
-
 }

--- a/src/main/java/com/mojh/dailybudget/member/dto/MemberSignupRequest.java
+++ b/src/main/java/com/mojh/dailybudget/member/dto/MemberSignupRequest.java
@@ -22,7 +22,7 @@ public class MemberSignupRequest {
     @Size(min = 8, max = 20)
     private String password;
 
-    @ValidEnum
+    @ValidEnum(enumClass = Role.class)
     private Role role;
 
     @NotBlank

--- a/src/test/java/com/mojh/dailybudget/expenditure/service/ExpenditureServiceMockTest.java
+++ b/src/test/java/com/mojh/dailybudget/expenditure/service/ExpenditureServiceMockTest.java
@@ -364,7 +364,7 @@ class ExpenditureServiceMockTest {
         Long expenditureId = expenditure.getId();
         Expenditure captured = captureExpenditure(expenditure);
         ExpenditureUpdateRequest requet = ExpenditureUpdateRequest.builder()
-                                                                  .category(expenditure.getCategoryType())
+                                                                  .category(expenditure.getCategoryType().toString())
                                                                   .amount(expenditure.getAmount() + 10000L)
                                                                   .memo(expenditure.getMemo() + " 수정")
                                                                   .build();
@@ -396,7 +396,7 @@ class ExpenditureServiceMockTest {
         Long expenditureId = expenditure.getId();
         Expenditure captured = captureExpenditure(expenditure);
         ExpenditureUpdateRequest requet = ExpenditureUpdateRequest.builder()
-                                                                  .category(FOOD)
+                                                                  .category(FOOD.toString())
                                                                   .build();
         given(categorySerivce.findByCategoryType(requet.getCategory())).willReturn(expenditure.getCategory());
         given(expenditureRepository.findById(expenditureId)).willReturn(Optional.of(expenditure));
@@ -425,7 +425,7 @@ class ExpenditureServiceMockTest {
         Long expenditureId = expenditure.getId();
         Member otherMember = MemberFixture.MEMBER2();
         ExpenditureUpdateRequest requet = ExpenditureUpdateRequest.builder()
-                                                                  .category(FOOD)
+                                                                  .category(FOOD.toString())
                                                                   .amount(30000L)
                                                                   .build();
         given(categorySerivce.findByCategoryType(requet.getCategory())).willReturn(expenditure.getCategory());


### PR DESCRIPTION
## 📃 설명

- resolves #30 
- 

## 🔨 작업 내용

1. enum type 유효성 검증 방식 수정
   - 기존
     - enum class 내의 `@JsonCreator` 적용한 함수를 만들고 입력된 문자열이 해당 enum 필드에 매칭되는지 확인하고 없으면 null 반환
     - custom validator에서 단순히 null 체크하는 방식
     - 수정 API 처럼 API에 따라서 enum 필드가 null을 허용해야될 때도 있는데 입력이 안돼서 null인지 enum 필드에 매칭되는 값이 없어서 null인지 구분하기 힘듬
   - 변경
     - 유효성 검증 annotation에다가 null 허용 필드를 만들고 custom validator에서 null 체크와 enum 필드에 매칭 여부를 같이 확인하여 검증
## 💬 기타 사항

- 