### PR TITLE
test: 지출 생성 테스트 추가

### DIFF
--- a/src/main/java/com/mojh/dailybudget/expenditure/controller/ExpenditureController.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/controller/ExpenditureController.java
@@ -38,12 +38,9 @@ public class ExpenditureController {
     @PostMapping
     public ResponseEntity createExpenditure(@RequestBody @Valid final ExpenditureCreateRequest request,
                                             @LoginMember final Member member,
-                                            HttpServletRequest sr) {
+                                            HttpServletRequest httpServletRequest) {
         Long id = expenditureService.createExpenditure(request, member);
-        URI location = ServletUriComponentsBuilder.fromCurrentRequestUri()
-                                                  .path("/{id}")
-                                                  .buildAndExpand(id)
-                                                  .toUri();
+        URI location = URI.create(String.format("%s/%d", httpServletRequest.getRequestURI(), id));
 
         return ResponseEntity.created(location).build();
     }
@@ -57,8 +54,7 @@ public class ExpenditureController {
 
     @GetMapping
     public ApiResponse<ExpenditureListResponse> retrieveExpenditureList(
-            @ModelAttribute @Valid final ExpenditureListRetrieveRequest request, @LoginMember final Member member
-    ) {
+            @ModelAttribute @Valid final ExpenditureListRetrieveRequest request, @LoginMember final Member member) {
         ExpenditureListResponse response = expenditureService.retrieveExpenditureList(request, member);
         return ApiResponse.succeed(response);
     }

--- a/src/main/java/com/mojh/dailybudget/expenditure/dto/request/ExpenditureCreateRequest.java
+++ b/src/main/java/com/mojh/dailybudget/expenditure/dto/request/ExpenditureCreateRequest.java
@@ -6,6 +6,7 @@ import com.mojh.dailybudget.common.vaildation.ValidEnum;
 import com.mojh.dailybudget.expenditure.domain.Expenditure;
 import com.mojh.dailybudget.member.domain.Member;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Range;
@@ -22,6 +23,7 @@ public class ExpenditureCreateRequest {
     @ValidEnum(enumClass = CategoryType.class)
     private String category;
 
+    @NotNull
     @Range(min = 0L, max = 1000000000000L)
     private Long amount;
 
@@ -34,6 +36,7 @@ public class ExpenditureCreateRequest {
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime expenditureAt;
 
+    @Builder
     public ExpenditureCreateRequest(String category, Long amount, String memo,
                                     Boolean excludeFromTotal, LocalDateTime expenditureAt) {
         this.category = category;

--- a/src/test/java/com/mojh/dailybudget/expenditure/service/ExpenditureServiceMockTest.java
+++ b/src/test/java/com/mojh/dailybudget/expenditure/service/ExpenditureServiceMockTest.java
@@ -8,6 +8,7 @@ import com.mojh.dailybudget.common.exception.DailyBudgetAppException;
 import com.mojh.dailybudget.common.exception.ErrorCode;
 import com.mojh.dailybudget.expenditure.ExpenditureFixture;
 import com.mojh.dailybudget.expenditure.domain.Expenditure;
+import com.mojh.dailybudget.expenditure.dto.request.ExpenditureCreateRequest;
 import com.mojh.dailybudget.expenditure.dto.request.ExpenditureListRetrieveRequest;
 import com.mojh.dailybudget.expenditure.dto.request.ExpenditureUpdateRequest;
 import com.mojh.dailybudget.expenditure.dto.response.ExpenditureListResponse;
@@ -39,6 +40,7 @@ import static com.mojh.dailybudget.expenditure.ExpenditureTestUtils.totalExpendi
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -71,6 +73,28 @@ class ExpenditureServiceMockTest {
         expenditureListFixture = ExpenditureFixture.EXPENDITURE_LIST();
     }
 
+    @Test
+    @DisplayName("지출 정보를 생성한다.")
+    void createExpenditure() {
+        // given
+        Member member = member1;
+        Expenditure expenditure = expenditureListFixture.get(0);
+        ExpenditureCreateRequest requet = new ExpenditureCreateRequest(expenditure.getCategoryType().toString(),
+                expenditure.getAmount(), expenditure.getMemo(), expenditure.getExcludeFromTotal(),
+                expenditure.getExpenditureAt());
+        given(categorySerivce.findByCategoryType(requet.getCategory())).willReturn(expenditure.getCategory());
+        given(expenditureRepository.save(any(Expenditure.class))).willReturn(expenditure);
+
+        // when
+        Long actual = expenditureService.createExpenditure(requet, member);
+
+        // then
+        assertAll(
+                () -> assertThat(actual).isEqualTo(expenditure.getId()),
+                () -> verify(categorySerivce).findByCategoryType(requet.getCategory()),
+                () -> verify(expenditureRepository).save(any(Expenditure.class))
+        );
+    }
 
     @Test
     @DisplayName("지출의 상세 내용을 조회한다.")


### PR DESCRIPTION
## 📃 설명

- resolves #32
- 

## 🔨 작업 내용

1. 지출 생성 service layer 단위 테스트 작성
2. 지출 생성 controller layer 통합 테스트
2. 지출 생성할 때 location header 값 형태 변경
   - `/api/expenditures/{id}` 형태로 수정
   - 즉 `/api/expenditures/5` 같은 형태로 반환

## 💬 기타 사항

- 